### PR TITLE
NOR-6831: Forbid non-strings for one hot encoding

### DIFF
--- a/src/dataframe processing/One-hot encoding/specification.json
+++ b/src/dataframe processing/One-hot encoding/specification.json
@@ -28,10 +28,10 @@
             "FromDataframe": "input",
             "MaxNr": 1,
             "MinNr": 1,
-            "AllowNumeric": true,
+            "AllowNumeric": false,
             "AllowStrings": true,
-            "AllowTimestamps": true,
-            "AllowBooleans": true,
+            "AllowTimestamps": false,
+            "AllowBooleans": false,
             "AllowNull": false
         },
         {


### PR DESCRIPTION
`pd.get_dummies` doesn't work for non-strings, causing a duplicate column to appear if the `append` option is checked